### PR TITLE
Resolving the CI-failure due to the wrong Xcode-version

### DIFF
--- a/.github/actions/configure-xcode/action.yml
+++ b/.github/actions/configure-xcode/action.yml
@@ -1,0 +1,17 @@
+name: Configure XCode
+description: Configure the workflow to use the latest XCode version
+
+runs:
+  using: composite
+  steps:
+    # Get xcode version from .xcode-version
+    - name: Determine Xcode Version
+      id: xcode-version
+      shell: bash
+      run: |
+        echo "version=$(cat .xcode-version)" >> $GITHUB_OUTPUT
+    # Make sure we use the correct xcode version
+    - name: Select Xcode Version
+      uses: maxim-lobanov/setup-xcode@v1.6.0
+      with:
+        xcode-version: ${{ steps.xcode-version.outputs.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+
+    - name: Configure Xcode
+      uses: ./.github/actions/configure-xcode
+
     - name: Build
       run: swift build -v
+      
     - name: Run tests
       run: swift test -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
   push:
     branches: [ "main", "develop", "klogi/*" ]
-  pull-request:
+  pull_request:
     branches: [ "main", "develop", "klogi/*" ]
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,9 @@ name: CI
 on:
   workflow_dispatch:
   push:
-    branches: [ "main", "develop" ]
+    branches: [ "main", "develop", "klogi/*" ]
+  pull-request:
+    branches: [ "main", "develop", "klogi/*" ]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# The CI workflow to build the library (triggers manually or by pushing code to `main` or `develop`)
+# The CI workflow to build the library (triggers manually, by pushing code or by opening a pull request to `main` or `develop`)
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-swift
 
 name: CI
@@ -6,9 +6,9 @@ name: CI
 on:
   workflow_dispatch:
   push:
-    branches: [ "main", "develop", "klogi/*" ]
+    branches: [ "main", "develop" ]
   pull-request:
-    branches: [ "main", "develop", "klogi/*" ]
+    branches: [ "main", "develop" ]
 
 jobs:
   build:


### PR DESCRIPTION
There was an issue executing tests on the CI: https://github.com/ksloginov/LiveScoreboard-Assignment/actions/runs/12988539608

The root cause: by default, the GitHub Action Runner is using the old Xcode v.15.4, which doesn't support the latest Swift 6.0 & new frameworks such as Swift Testing.

By introducing a new action, I'm enforcing GHA to pick the latest Xcode version available (16.2 per today) & it [resolves the issue](https://github.com/ksloginov/LiveScoreboard-Assignment/actions/runs/12989378928).